### PR TITLE
chore: updated colour scheme

### DIFF
--- a/internal/ui/common/theme_dark.go
+++ b/internal/ui/common/theme_dark.go
@@ -214,16 +214,16 @@ func MonokaiTheme() Theme {
 	}
 }
 
-// MonokaiProTheme - Monokai Pro dark, with vibrant accents on a black base
+// MonokaiProTheme - Monokai Pro accents on ristretto's warm dark brown base
 func MonokaiProTheme() Theme {
 	return Theme{
 		ID:   ThemeMonokaiPro,
 		Name: "Monokai Pro",
 		Colors: ThemeColors{
-			Background:    lipgloss.Color("#0d1117"),
-			Foreground:    lipgloss.Color("#fcfcfa"),
-			Muted:         lipgloss.Color("#727072"),
-			Border:        lipgloss.Color("#21262d"),
+			Background:    lipgloss.Color("#2c2525"),
+			Foreground:    lipgloss.Color("#e6d9db"),
+			Muted:         lipgloss.Color("#72696a"),
+			Border:        lipgloss.Color("#36302f"),
 			BorderFocused: lipgloss.Color("#ffd866"),
 
 			Primary:   lipgloss.Color("#ffd866"), // Yellow
@@ -233,13 +233,13 @@ func MonokaiProTheme() Theme {
 			Error:     lipgloss.Color("#ff6188"), // Red/Pink
 			Info:      lipgloss.Color("#78dce8"), // Cyan
 
-			Surface0: lipgloss.Color("#0d1117"),
-			Surface1: lipgloss.Color("#161b22"),
-			Surface2: lipgloss.Color("#21262d"),
-			Surface3: lipgloss.Color("#30363d"),
+			Surface0: lipgloss.Color("#2c2525"),
+			Surface1: lipgloss.Color("#36302f"),
+			Surface2: lipgloss.Color("#403e41"),
+			Surface3: lipgloss.Color("#524c4d"),
 
-			Selection: lipgloss.Color("#30363d"),
-			Highlight: lipgloss.Color("#21262d"),
+			Selection: lipgloss.Color("#403e41"),
+			Highlight: lipgloss.Color("#36302f"),
 		},
 	}
 }


### PR DESCRIPTION
This pull request updates the `MonokaiProTheme` in `internal/ui/common/theme_dark.go` to use a warm dark brown base inspired by the ristretto theme, instead of a black base. The color palette for background, foreground, muted, border, surface, selection, and highlight elements has been adjusted for a warmer appearance.

Theme color changes:

* Changed `Background`, `Foreground`, `Muted`, and `Border` colors to warmer, brown-based tones for the `MonokaiProTheme`, moving away from the previous black base.
* Updated `Surface0`, `Surface1`, `Surface2`, and `Surface3` colors to match the new warm brown palette.
* Modified `Selection` and `Highlight` colors for better consistency with the new theme base.