### PR TITLE
Issue 2 add icons to note the current status of

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,0 +1,16 @@
+# Issue #2: Add icons to note the current status of a conversation to indicate when action is needed
+
+https://github.com/tlepoid/tumuxi/issues/2
+
+---
+
+Add Status Detection
+
+Status | Symbol | What It Means
+-- | -- | --
+Running | ● green | Agent is actively working
+Waiting | ◐ yellow | Needs your input
+Idle | ○ gray | Ready for commands
+Error | ✕ red | Something went wrong
+
+

--- a/internal/app/app_input_keys.go
+++ b/internal/app/app_input_keys.go
@@ -23,6 +23,9 @@ func (a *App) syncActiveWorkspacesToDashboard() {
 		activeWorkspaces[wsID] = true
 	}
 	a.dashboard.SetActiveWorkspaces(activeWorkspaces)
+	if a.center != nil {
+		a.dashboard.SetWorkspaceStatuses(a.center.GetWorkspaceStatuses())
+	}
 }
 
 // handleKeyPress handles keyboard input

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -176,11 +176,16 @@ func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 	}
 	tab.mu.Unlock()
 
-	logging.Debug("TabConversationStatus tab=%s assistant=%s running=%v detached=%v session=%q", tab.ID, tab.Assistant, running, detached, sessionName)
+	// Throttled diagnostic: log once per 5 seconds per tab to help debug unexpected ○ indicators.
+	now := time.Now()
+	if now.Sub(tab.lastStatusLogAt) >= 5*time.Second {
+		tab.lastStatusLogAt = now
+		logging.Info("TabConversationStatus tab=%s assistant=%s running=%v detached=%v session=%q", tab.ID, tab.Assistant, running, detached, sessionName)
+	}
 
 	switch {
 	case !running && !detached:
-		return ConvStatusEnded
+		return ConvStatusIdle
 	case running && !detached:
 		return ConvStatusWaiting // caller upgrades to Running when tmux says active
 	default:
@@ -190,7 +195,7 @@ func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 		if sessionName != "" {
 			return ConvStatusWaiting
 		}
-		return ConvStatusEnded
+		return ConvStatusIdle
 	}
 }
 
@@ -221,7 +226,7 @@ func (m *Model) GetWorkspaceStatuses() map[string]common.AgentStatus {
 			var s common.AgentStatus
 			switch {
 			case !running && !detached:
-				s = common.AgentStatusError
+				s = common.AgentStatusIdle
 			case running && !detached:
 				s = common.AgentStatusWaiting // upgraded to Running by caller if tmux active
 			default:

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/tlepoid/tumuxi/internal/logging"
 	"github.com/tlepoid/tumuxi/internal/perf"
+	"github.com/tlepoid/tumuxi/internal/ui/common"
 	"github.com/tlepoid/tumuxi/internal/ui/compositor"
 )
 
@@ -143,6 +145,119 @@ func (m *Model) isChatTab(tab *Tab) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// ConversationStatus represents the current visible status of a conversation tab.
+type ConversationStatus int
+
+const (
+	ConvStatusIdle    ConversationStatus = iota // ○ gray  - ready/disconnected
+	ConvStatusRunning                           // ● green  - actively working
+	ConvStatusWaiting                           // ◐ yellow - needs user input
+	ConvStatusError                             // ✕ red    - something went wrong
+)
+
+// TabConversationStatus returns the display status for a chat tab.
+func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
+	if tab == nil || tab.isClosed() {
+		return ConvStatusIdle
+	}
+	if !m.isChatTab(tab) {
+		return ConvStatusIdle
+	}
+	tab.mu.Lock()
+	detached := tab.Detached
+	running := tab.Running
+	tab.mu.Unlock()
+
+	// Process stopped without the user detaching: treat as error.
+	if !running && !detached {
+		return ConvStatusError
+	}
+	// Detached or cleanly stopped: idle.
+	if !running || detached {
+		return ConvStatusIdle
+	}
+	// Recent visible output: running.
+	if m.IsTabActive(tab) {
+		return ConvStatusRunning
+	}
+	// Connected but quiet: check whether the terminal is waiting for input.
+	if m.tabIsWaiting(tab) {
+		return ConvStatusWaiting
+	}
+	return ConvStatusIdle
+}
+
+// tabIsWaiting returns true if the terminal cursor line looks like an input prompt.
+func (m *Model) tabIsWaiting(tab *Tab) bool {
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if tab.Terminal == nil {
+		return false
+	}
+	screen := tab.Terminal.Screen
+	cursorY := tab.Terminal.CursorY
+	if cursorY < 0 || cursorY >= len(screen) {
+		return false
+	}
+	var sb strings.Builder
+	for _, cell := range screen[cursorY] {
+		if cell.Rune != 0 {
+			sb.WriteRune(cell.Rune)
+		}
+	}
+	text := strings.TrimRight(sb.String(), " ")
+	return looksLikeInputPrompt(text)
+}
+
+// looksLikeInputPrompt returns true when text ends with a common user-input prompt pattern.
+func looksLikeInputPrompt(text string) bool {
+	if text == "" {
+		return false
+	}
+	lower := strings.ToLower(text)
+	for _, suffix := range []string{
+		"? ", "?", "> ", ">>> ", ">> ",
+		"[y/n]", "[y/n] ", "(y/n)", "(y/n) ",
+		"[yes/no]", "[yes/no] ",
+	} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetWorkspaceStatuses returns the aggregate AgentStatus for each workspace ID.
+// When a workspace has multiple tabs the most prominent status wins:
+// Error > Waiting > Running > Idle.
+func (m *Model) GetWorkspaceStatuses() map[string]common.AgentStatus {
+	result := make(map[string]common.AgentStatus)
+	for wsID, tabs := range m.tabsByWorkspace {
+		best := common.AgentStatusIdle
+		for _, tab := range tabs {
+			s := convToAgentStatus(m.TabConversationStatus(tab))
+			if s > best {
+				best = s
+			}
+		}
+		result[wsID] = best
+	}
+	return result
+}
+
+func convToAgentStatus(s ConversationStatus) common.AgentStatus {
+	switch s {
+	case ConvStatusRunning:
+		return common.AgentStatusRunning
+	case ConvStatusWaiting:
+		return common.AgentStatusWaiting
+	case ConvStatusError:
+		return common.AgentStatusError
+	default:
+		return common.AgentStatusIdle
 	}
 }
 

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -1,7 +1,6 @@
 package center
 
 import (
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -158,7 +157,9 @@ const (
 	ConvStatusError                             // ✕ red    - something went wrong
 )
 
-// TabConversationStatus returns the display status for a chat tab.
+// TabConversationStatus returns the display status for a chat tab based on
+// process state alone. Callers with tmux activity data should upgrade
+// ConvStatusWaiting to ConvStatusRunning when tmux confirms recent output.
 func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 	if tab == nil || tab.isClosed() {
 		return ConvStatusIdle
@@ -169,76 +170,68 @@ func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 	tab.mu.Lock()
 	detached := tab.Detached
 	running := tab.Running
+	sessionName := tab.SessionName
+	if sessionName == "" && tab.Agent != nil {
+		sessionName = tab.Agent.Session
+	}
 	tab.mu.Unlock()
 
-	// Process stopped without the user detaching: treat as error.
-	if !running && !detached {
+	switch {
+	case !running && !detached:
 		return ConvStatusError
-	}
-	// Detached or cleanly stopped: idle.
-	if !running || detached {
+	case running && !detached:
+		return ConvStatusWaiting // caller upgrades to Running when tmux says active
+	default:
+		// detached=true: PTY dropped or user detached.
+		// If a tmux session name is known the session may still be alive and
+		// waiting for input — show Waiting so the user notices it.
+		if sessionName != "" {
+			return ConvStatusWaiting
+		}
 		return ConvStatusIdle
 	}
-	// Recent visible output: running.
-	if m.IsTabActive(tab) {
-		return ConvStatusRunning
-	}
-	// Connected but quiet: check whether the terminal is waiting for input.
-	if m.tabIsWaiting(tab) {
-		return ConvStatusWaiting
-	}
-	return ConvStatusIdle
 }
 
-// tabIsWaiting returns true if the terminal cursor line looks like an input prompt.
-func (m *Model) tabIsWaiting(tab *Tab) bool {
-	tab.mu.Lock()
-	defer tab.mu.Unlock()
-	if tab.Terminal == nil {
-		return false
-	}
-	screen := tab.Terminal.Screen
-	cursorY := tab.Terminal.CursorY
-	if cursorY < 0 || cursorY >= len(screen) {
-		return false
-	}
-	var sb strings.Builder
-	for _, cell := range screen[cursorY] {
-		if cell.Rune != 0 {
-			sb.WriteRune(cell.Rune)
-		}
-	}
-	text := strings.TrimRight(sb.String(), " ")
-	return looksLikeInputPrompt(text)
-}
-
-// looksLikeInputPrompt returns true when text ends with a common user-input prompt pattern.
-func looksLikeInputPrompt(text string) bool {
-	if text == "" {
-		return false
-	}
-	lower := strings.ToLower(text)
-	for _, suffix := range []string{
-		"? ", "?", "> ", ">>> ", ">> ",
-		"[y/n]", "[y/n] ", "(y/n)", "(y/n) ",
-		"[yes/no]", "[yes/no] ",
-	} {
-		if strings.HasSuffix(lower, suffix) {
-			return true
-		}
-	}
-	return false
-}
-
-// GetWorkspaceStatuses returns the aggregate AgentStatus for each workspace ID.
-// When a workspace has multiple tabs the most prominent status wins:
-// Error > Waiting > Running > Idle.
+// GetWorkspaceStatuses returns the base AgentStatus for each workspace ID,
+// derived solely from tab process state (not screen-activity heuristics).
+//
+// Callers that also have tmux activity data should upgrade AgentStatusWaiting
+// to AgentStatusRunning when tmux confirms recent output in that workspace.
+// This two-signal approach avoids false "idle" readings caused by tmux
+// continuously refreshing the terminal with escape sequences.
 func (m *Model) GetWorkspaceStatuses() map[string]common.AgentStatus {
 	result := make(map[string]common.AgentStatus)
 	for wsID, tabs := range m.tabsByWorkspace {
 		best := common.AgentStatusIdle
 		for _, tab := range tabs {
-			s := convToAgentStatus(m.TabConversationStatus(tab))
+			if tab == nil || tab.isClosed() || !m.isChatTab(tab) {
+				continue
+			}
+			tab.mu.Lock()
+			running := tab.Running
+			detached := tab.Detached
+			sessionName := tab.SessionName
+			if sessionName == "" && tab.Agent != nil {
+				sessionName = tab.Agent.Session
+			}
+			tab.mu.Unlock()
+
+			var s common.AgentStatus
+			switch {
+			case !running && !detached:
+				s = common.AgentStatusError
+			case running && !detached:
+				s = common.AgentStatusWaiting // upgraded to Running by caller if tmux active
+			default:
+				// detached=true: PTY dropped or user detached.
+				// If a tmux session name is known the session may still be alive
+				// and waiting for input — show Waiting so the user notices it.
+				if sessionName != "" {
+					s = common.AgentStatusWaiting
+				} else {
+					s = common.AgentStatusIdle
+				}
+			}
 			if s > best {
 				best = s
 			}
@@ -246,19 +239,6 @@ func (m *Model) GetWorkspaceStatuses() map[string]common.AgentStatus {
 		result[wsID] = best
 	}
 	return result
-}
-
-func convToAgentStatus(s ConversationStatus) common.AgentStatus {
-	switch s {
-	case ConvStatusRunning:
-		return common.AgentStatusRunning
-	case ConvStatusWaiting:
-		return common.AgentStatusWaiting
-	case ConvStatusError:
-		return common.AgentStatusError
-	default:
-		return common.AgentStatusIdle
-	}
 }
 
 // StartPTYReaders starts reading from all PTYs across all workspaces

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -151,9 +151,9 @@ func (m *Model) isChatTab(tab *Tab) bool {
 type ConversationStatus int
 
 const (
-	ConvStatusIdle    ConversationStatus = iota // ○ gray  - ready/disconnected
+	ConvStatusIdle    ConversationStatus = iota // ○ gray   - no session or session ended
 	ConvStatusRunning                           // ● green  - actively working
-	ConvStatusWaiting                           // ◐ yellow - needs user input
+	ConvStatusWaiting                           // ◐ yellow - session alive, needs attention
 	ConvStatusError                             // ✕ red    - something went wrong
 )
 
@@ -176,9 +176,11 @@ func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 	}
 	tab.mu.Unlock()
 
+	logging.Debug("TabConversationStatus tab=%s assistant=%s running=%v detached=%v session=%q", tab.ID, tab.Assistant, running, detached, sessionName)
+
 	switch {
 	case !running && !detached:
-		return ConvStatusError
+		return ConvStatusEnded
 	case running && !detached:
 		return ConvStatusWaiting // caller upgrades to Running when tmux says active
 	default:
@@ -188,7 +190,7 @@ func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 		if sessionName != "" {
 			return ConvStatusWaiting
 		}
-		return ConvStatusIdle
+		return ConvStatusEnded
 	}
 }
 

--- a/internal/ui/center/model_render_tabbar.go
+++ b/internal/ui/center/model_render_tabbar.go
@@ -66,7 +66,9 @@ func (m *Model) renderTabBar() string {
 		agentStyle := lipgloss.NewStyle().Foreground(common.AgentColor(tab.Assistant))
 
 		// indicatorColor returns the status-appropriate foreground color for the indicator.
-		indicatorColor := func() interface{ RGBA() (uint32, uint32, uint32, uint32) } {
+		indicatorColor := func() interface {
+			RGBA() (uint32, uint32, uint32, uint32)
+		} {
 			switch status {
 			case ConvStatusRunning:
 				return common.AgentColor(tab.Assistant)

--- a/internal/ui/center/model_render_tabbar.go
+++ b/internal/ui/center/model_render_tabbar.go
@@ -47,6 +47,10 @@ func (m *Model) renderTabBar() string {
 		var status ConversationStatus
 		if isChat {
 			status = m.TabConversationStatus(tab)
+			// Upgrade Waiting→Running when the tab has recent visible output.
+			if status == ConvStatusWaiting && m.IsTabActive(tab) {
+				status = ConvStatusRunning
+			}
 			switch status {
 			case ConvStatusRunning:
 				indicator = common.Icons.Running + " "

--- a/internal/ui/center/model_render_tabbar.go
+++ b/internal/ui/center/model_render_tabbar.go
@@ -41,25 +41,39 @@ func (m *Model) renderTabBar() string {
 			name = tab.Assistant
 		}
 
-		// Check if tab is disconnected (detached or stopped)
-		tab.mu.Lock()
-		tabDisconnected := tab.Detached || !tab.Running
-		tab.mu.Unlock()
-
-		// Add brand color indicator for agent tabs (not file viewers)
+		// Determine conversation status for chat tabs
 		var indicator string
-		var tabActive bool
 		isChat := m.isChatTab(tab)
+		var status ConversationStatus
 		if isChat {
-			if tabDisconnected {
-				indicator = common.Icons.Idle + " " // Disconnected indicator
-			} else {
-				indicator = common.Icons.Running + " " // Brand color dot
+			status = m.TabConversationStatus(tab)
+			switch status {
+			case ConvStatusRunning:
+				indicator = common.Icons.Running + " "
+			case ConvStatusWaiting:
+				indicator = common.Icons.Waiting + " "
+			case ConvStatusError:
+				indicator = common.Icons.Error + " "
+			default: // ConvStatusIdle
+				indicator = common.Icons.Idle + " "
 			}
-			tabActive = m.IsTabActive(tab)
 		}
 
 		agentStyle := lipgloss.NewStyle().Foreground(common.AgentColor(tab.Assistant))
+
+		// indicatorColor returns the status-appropriate foreground color for the indicator.
+		indicatorColor := func() interface{ RGBA() (uint32, uint32, uint32, uint32) } {
+			switch status {
+			case ConvStatusRunning:
+				return common.AgentColor(tab.Assistant)
+			case ConvStatusWaiting:
+				return common.ColorWarning()
+			case ConvStatusError:
+				return common.ColorError()
+			default:
+				return common.ColorMuted()
+			}
+		}
 
 		// Build tab content with close affordance
 		closeLabel := m.styles.Muted.Render("×")
@@ -69,18 +83,21 @@ func (m *Model) renderTabBar() string {
 			// Active tab - each part styled with same background
 			bg := common.ColorSurface2()
 			pad := lipgloss.NewStyle().Background(bg).Render(" ")
-			// Use muted color for disconnected tabs
-			indicatorFg := agentStyle.GetForeground()
-			if tabDisconnected {
-				indicatorFg = common.ColorMuted()
-			}
-			indicatorPart := lipgloss.NewStyle().Foreground(indicatorFg).Background(bg).Render(indicator)
-			// Use primary color and bold when actively working, muted when disconnected
-			nameStyle := lipgloss.NewStyle().Foreground(common.ColorForeground()).Background(bg)
-			if tabDisconnected {
-				nameStyle = nameStyle.Foreground(common.ColorMuted())
-			} else if tabActive {
+			indicatorPart := lipgloss.NewStyle().Foreground(indicatorColor()).Background(bg).Render(indicator)
+			// Name color reflects status: running→primary+bold, waiting→warning, error→error, idle→muted
+			nameStyle := lipgloss.NewStyle().Background(bg)
+			switch status {
+			case ConvStatusRunning:
 				nameStyle = nameStyle.Foreground(common.ColorPrimary()).Bold(true)
+			case ConvStatusWaiting:
+				nameStyle = nameStyle.Foreground(common.ColorWarning())
+			case ConvStatusError:
+				nameStyle = nameStyle.Foreground(common.ColorError())
+			default:
+				nameStyle = nameStyle.Foreground(common.ColorMuted())
+			}
+			if !isChat {
+				nameStyle = nameStyle.Foreground(common.ColorForeground())
 			}
 			namePart := nameStyle.Render(name)
 			space := lipgloss.NewStyle().Background(bg).Render(" ")
@@ -88,22 +105,22 @@ func (m *Model) renderTabBar() string {
 			rendered = pad + indicatorPart + namePart + space + closePart + pad
 			style = m.styles.ActiveTab
 		} else {
-			// Inactive tab - muted with colored indicator, or primary color + bold when active
+			// Inactive tab
 			var nameStyled string
-			if tabDisconnected {
-				nameStyled = m.styles.Muted.Render(name)
-			} else if tabActive {
+			switch status {
+			case ConvStatusRunning:
 				nameStyled = lipgloss.NewStyle().Foreground(common.ColorPrimary()).Bold(true).Render(name)
-			} else {
+			case ConvStatusWaiting:
+				nameStyled = lipgloss.NewStyle().Foreground(common.ColorWarning()).Render(name)
+			case ConvStatusError:
+				nameStyled = lipgloss.NewStyle().Foreground(common.ColorError()).Render(name)
+			default:
 				nameStyled = m.styles.Muted.Render(name)
 			}
-			// Use muted indicator color for disconnected tabs
-			var indicatorStyled string
-			if tabDisconnected {
-				indicatorStyled = m.styles.Muted.Render(indicator)
-			} else {
-				indicatorStyled = agentStyle.Render(indicator)
+			if !isChat {
+				nameStyled = m.styles.Muted.Render(name)
 			}
+			indicatorStyled := lipgloss.NewStyle().Foreground(indicatorColor()).Render(indicator)
 			content := indicatorStyled + nameStyled + " " + closeLabel
 			rendered = m.styles.Tab.Render(content)
 			style = m.styles.Tab

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -85,6 +85,7 @@ type Tab struct {
 	ptyRestartCount   int
 	ptyRestartSince   time.Time
 	lastFocusedAt     time.Time
+	lastStatusLogAt   time.Time // throttle for TabConversationStatus diagnostic log
 
 	// Snapshot cache for VTermLayer - avoid recreating snapshot when terminal unchanged
 	cachedSnap       *compositor.VTermSnapshot

--- a/internal/ui/common/icons.go
+++ b/internal/ui/common/icons.go
@@ -7,8 +7,10 @@ var Icons = struct {
 	Clean   string
 	Dirty   string
 	Running string
+	Waiting string
 	Idle    string
 	Pending string
+	Error   string
 
 	// Actions
 	Add    string
@@ -45,8 +47,10 @@ var Icons = struct {
 	Clean:   "✓",
 	Dirty:   "●",
 	Running: "●",
+	Waiting: "◐",
 	Idle:    "○",
 	Pending: "◌",
+	Error:   "✕",
 
 	// Actions
 	Add:    "+",

--- a/internal/ui/common/status.go
+++ b/internal/ui/common/status.go
@@ -1,0 +1,42 @@
+package common
+
+import "image/color"
+
+// AgentStatus is the aggregated conversation status for a workspace,
+// derived from its tabs and used for dashboard display.
+type AgentStatus int
+
+const (
+	AgentStatusIdle    AgentStatus = iota // ○ gray  - no agent or disconnected
+	AgentStatusRunning                    // ● green  - actively working
+	AgentStatusWaiting                    // ◐ yellow - needs user input
+	AgentStatusError                      // ✕ red    - something went wrong
+)
+
+// AgentStatusIcon returns the display icon for the given status.
+func AgentStatusIcon(s AgentStatus) string {
+	switch s {
+	case AgentStatusRunning:
+		return Icons.Running
+	case AgentStatusWaiting:
+		return Icons.Waiting
+	case AgentStatusError:
+		return Icons.Error
+	default:
+		return Icons.Idle
+	}
+}
+
+// AgentStatusColor returns the display color for the given status.
+func AgentStatusColor(s AgentStatus) color.Color {
+	switch s {
+	case AgentStatusRunning:
+		return ColorSuccess()
+	case AgentStatusWaiting:
+		return ColorWarning()
+	case AgentStatusError:
+		return ColorError()
+	default:
+		return ColorMuted()
+	}
+}

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -66,10 +66,7 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		}
 		style = applyDirtyForeground(style, dirty, active, selected)
 
-		// Status icon always at the left edge (1 char) so it's visible at any sidebar width.
-		agentStatus := m.workspaceStatuses[row.ActivityWorkspaceID]
-		iconStr := lipgloss.NewStyle().Foreground(common.AgentStatusColor(agentStatus)).Render(common.AgentStatusIcon(agentStatus))
-		iconWidth := lipgloss.Width(iconStr)
+		prefix := " "
 
 		// Reserve space for delete icon to keep status aligned
 		deleteSlot := "   "
@@ -78,9 +75,9 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			deleteSlot = " " + common.Icons.Close + " "
 		}
 
-		// Truncate project name to fit within pane (width - border - padding - icon - status - deleteSlot)
+		// Truncate project name to fit within pane (width - border - padding - status - deleteSlot)
 		name := row.Project.Name
-		maxNameWidth := m.width - 3 - lipgloss.Width(status) - deleteSlotWidth - iconWidth - 1
+		maxNameWidth := m.width - 3 - lipgloss.Width(status) - deleteSlotWidth - lipgloss.Width(prefix) - 1
 		if maxNameWidth > 0 && lipgloss.Width(name) > maxNameWidth {
 			runes := []rune(name)
 			for len(runes) > 0 && lipgloss.Width(string(runes)) > maxNameWidth-1 {
@@ -91,10 +88,10 @@ func (m *Model) renderRow(row Row, selected bool) string {
 
 		// Track delete slot position for click detection
 		if selected {
-			m.deleteIconX = iconWidth + lipgloss.Width(style.Render(name))
+			m.deleteIconX = lipgloss.Width(style.Render(prefix + name))
 		}
 
-		return iconStr + style.Render(name+deleteSlot) + status
+		return style.Render(prefix+name+deleteSlot) + status
 
 	case RowWorkspace:
 		styledPrefix := " "
@@ -122,7 +119,11 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		}
 
 		// Status icon always at the left edge (1 char) so it's visible at any sidebar width.
+		// Upgrade Waiting→Running when tmux confirms recent output in this workspace.
 		agentStatus := m.workspaceStatuses[row.ActivityWorkspaceID]
+		if agentStatus == common.AgentStatusWaiting && m.activeWorkspaceIDs[row.ActivityWorkspaceID] {
+			agentStatus = common.AgentStatusRunning
+		}
 		iconStr := lipgloss.NewStyle().Foreground(common.AgentStatusColor(agentStatus)).Render(common.AgentStatusIcon(agentStatus))
 		iconWidth := lipgloss.Width(iconStr)
 

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -34,7 +34,6 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		return style.Render("[tumuxi]")
 
 	case RowProject:
-		prefix := " "
 		status := ""
 		statusText := ""
 		dirty := false
@@ -67,6 +66,11 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		}
 		style = applyDirtyForeground(style, dirty, active, selected)
 
+		// Status icon always at the left edge (1 char) so it's visible at any sidebar width.
+		agentStatus := m.workspaceStatuses[row.ActivityWorkspaceID]
+		iconStr := lipgloss.NewStyle().Foreground(common.AgentStatusColor(agentStatus)).Render(common.AgentStatusIcon(agentStatus))
+		iconWidth := lipgloss.Width(iconStr)
+
 		// Reserve space for delete icon to keep status aligned
 		deleteSlot := "   "
 		deleteSlotWidth := 3
@@ -74,9 +78,9 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			deleteSlot = " " + common.Icons.Close + " "
 		}
 
-		// Truncate project name to fit within pane (width - border - padding - status - deleteSlot)
+		// Truncate project name to fit within pane (width - border - padding - icon - status - deleteSlot)
 		name := row.Project.Name
-		maxNameWidth := m.width - 3 - lipgloss.Width(status) - deleteSlotWidth - lipgloss.Width(prefix) - 1
+		maxNameWidth := m.width - 3 - lipgloss.Width(status) - deleteSlotWidth - iconWidth - 1
 		if maxNameWidth > 0 && lipgloss.Width(name) > maxNameWidth {
 			runes := []rune(name)
 			for len(runes) > 0 && lipgloss.Width(string(runes)) > maxNameWidth-1 {
@@ -87,13 +91,12 @@ func (m *Model) renderRow(row Row, selected bool) string {
 
 		// Track delete slot position for click detection
 		if selected {
-			m.deleteIconX = lipgloss.Width(style.Render(prefix + name))
+			m.deleteIconX = iconWidth + lipgloss.Width(style.Render(name))
 		}
 
-		return style.Render(prefix+name+deleteSlot) + status
+		return iconStr + style.Render(name+deleteSlot) + status
 
 	case RowWorkspace:
-		unstyledPrefix := " "
 		styledPrefix := " "
 		name := row.Workspace.Name
 		status := ""
@@ -118,6 +121,11 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			status = " " + statusText
 		}
 
+		// Status icon always at the left edge (1 char) so it's visible at any sidebar width.
+		agentStatus := m.workspaceStatuses[row.ActivityWorkspaceID]
+		iconStr := lipgloss.NewStyle().Foreground(common.AgentStatusColor(agentStatus)).Render(common.AgentStatusIcon(agentStatus))
+		iconWidth := lipgloss.Width(iconStr)
+
 		// Determine row style based on selection and active state
 		style := m.styles.WorkspaceRow
 		if selected {
@@ -136,8 +144,8 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			deleteSlot = " " + common.Icons.Close + " "
 		}
 
-		// Truncate workspace name to fit within pane (width - border - padding - status - deleteSlot)
-		prefixWidth := lipgloss.Width(unstyledPrefix) + lipgloss.Width(styledPrefix)
+		// Truncate workspace name to fit within pane (width - border - padding - icon - status - deleteSlot)
+		prefixWidth := iconWidth + lipgloss.Width(styledPrefix)
 		maxNameWidth := m.width - 3 - lipgloss.Width(status) - deleteSlotWidth - prefixWidth - 1
 		if maxNameWidth > 0 && lipgloss.Width(name) > maxNameWidth {
 			runes := []rune(name)
@@ -149,10 +157,10 @@ func (m *Model) renderRow(row Row, selected bool) string {
 
 		// Track delete slot position for click detection
 		if selected {
-			m.deleteIconX = lipgloss.Width(unstyledPrefix) + lipgloss.Width(style.Render(styledPrefix+name))
+			m.deleteIconX = iconWidth + lipgloss.Width(style.Render(styledPrefix+name))
 		}
 
-		return unstyledPrefix + style.Render(styledPrefix+name+deleteSlot) + status
+		return iconStr + style.Render(styledPrefix+name+deleteSlot) + status
 
 	case RowCreate:
 		unstyledPrefix := " "

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -82,7 +82,7 @@ type Model struct {
 	spinnerActive      bool                       // Whether spinner ticks are active
 
 	// Agent activity state
-	activeWorkspaceIDs map[string]bool            // Workspace IDs with active agents (synced from center)
+	activeWorkspaceIDs map[string]bool               // Workspace IDs with active agents (synced from center)
 	workspaceStatuses  map[string]common.AgentStatus // Per-workspace agent status (synced from center)
 
 	// Styles

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -82,7 +82,8 @@ type Model struct {
 	spinnerActive      bool                       // Whether spinner ticks are active
 
 	// Agent activity state
-	activeWorkspaceIDs map[string]bool // Workspace IDs with active agents (synced from center)
+	activeWorkspaceIDs map[string]bool            // Workspace IDs with active agents (synced from center)
+	workspaceStatuses  map[string]common.AgentStatus // Per-workspace agent status (synced from center)
 
 	// Styles
 	styles common.Styles
@@ -97,6 +98,7 @@ func New() *Model {
 		creatingWorkspaces: make(map[string]*data.Workspace),
 		deletingWorkspaces: make(map[string]bool),
 		activeWorkspaceIDs: make(map[string]bool),
+		workspaceStatuses:  make(map[string]common.AgentStatus),
 		cursor:             0,
 		focused:            true,
 		styles:             common.DefaultStyles(),
@@ -106,6 +108,11 @@ func New() *Model {
 // SetActiveWorkspaces updates the set of workspaces with active agents.
 func (m *Model) SetActiveWorkspaces(active map[string]bool) {
 	m.activeWorkspaceIDs = active
+}
+
+// SetWorkspaceStatuses updates the per-workspace agent status for indicator rendering.
+func (m *Model) SetWorkspaceStatuses(statuses map[string]common.AgentStatus) {
+	m.workspaceStatuses = statuses
 }
 
 // InvalidateStatus marks a workspace's cached status stale.


### PR DESCRIPTION
This pull request introduces conversation status detection and visual indicators for agent activity across tabs and workspaces, improving clarity for users about when action is needed or when agents are working. The changes add new status icons and colors, update tab and dashboard rendering to display these statuses, and provide logic for determining and propagating agent status.

Conversation status detection and representation:

* Added `ConversationStatus` and `AgentStatus` enums to represent conversation and agent states (Idle, Running, Waiting, Error), along with helper functions for icons and colors in `internal/ui/center/model_pty_status.go` and `internal/ui/common/status.go`. [[1]](diffhunk://#diff-2dab5992e14e25a41f83558a6269a89fba386a17a2d332fdf226830224fcdd44R150-R243) [[2]](diffhunk://#diff-f785b279d1c3b2b5453c2d0bbd10183397c5522d8ba6ad0ebdd3d0850e5a3a6dR1-R42)
* Introduced logic to determine conversation status for each tab and workspace, including methods `TabConversationStatus` and `GetWorkspaceStatuses` in the center model.

Visual indicator enhancements:

* Updated `internal/ui/common/icons.go` to include new icons for Waiting and Error statuses. [[1]](diffhunk://#diff-78bd935885b479f655d45d8268c17254afe6ad1d0148fe5bcbb48b2a679f5fefR10-R13) [[2]](diffhunk://#diff-78bd935885b479f655d45d8268c17254afe6ad1d0148fe5bcbb48b2a679f5fefR50-R53)
* Modified tab bar rendering in `internal/ui/center/model_render_tabbar.go` to show status-appropriate icons and colors for each chat tab, upgrading Waiting to Running when recent activity is detected. [[1]](diffhunk://#diff-649b37c4258859a4c1d250f05afb7e8705b75c2107ab15161c16d9f377bf4df3L44-R81) [[2]](diffhunk://#diff-649b37c4258859a4c1d250f05afb7e8705b75c2107ab15161c16d9f377bf4df3L72-R127)
* Enhanced dashboard workspace row rendering in `internal/ui/dashboard/dashboard_render.go` to display a status icon at the left edge for each workspace, reflecting agent activity and upgrading Waiting to Running based on tmux activity. [[1]](diffhunk://#diff-1bc789dfc1b7455edfcee10fa21101f00d2f49a0ccf3b9b56c949f92dc3c317aR121-R129) [[2]](diffhunk://#diff-1bc789dfc1b7455edfcee10fa21101f00d2f49a0ccf3b9b56c949f92dc3c317aL139-R149) [[3]](diffhunk://#diff-1bc789dfc1b7455edfcee10fa21101f00d2f49a0ccf3b9b56c949f92dc3c317aL152-R164)

State propagation and dashboard integration:

* Added per-workspace status tracking and setter methods in the dashboard model, and updated the sync logic to propagate workspace statuses from the center model. [[1]](diffhunk://#diff-8ad60b21509d63af54dad077821e5ca6e6642f450a9d64f777377d0aba587430R86) [[2]](diffhunk://#diff-8ad60b21509d63af54dad077821e5ca6e6642f450a9d64f777377d0aba587430R101) [[3]](diffhunk://#diff-8ad60b21509d63af54dad077821e5ca6e6642f450a9d64f777377d0aba587430R113-R117) [[4]](diffhunk://#diff-60200af34e08abd5397a66f4c10df59a067c318aaa5e52440f77e6a88a9322b1R26-R28)

Documentation:

* Added an issue file describing the new status icons and their meanings for conversations.