### PR TITLE
Issue 15 add ability to mark a chat as complete

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,16 +1,11 @@
-# Issue #2: Add icons to note the current status of a conversation to indicate when action is needed
+# Issue #15: Add ability to mark a chat as complete without deleting
 
-https://github.com/tlepoid/tumuxi/issues/2
+https://github.com/tlepoid/tumuxi/issues/15
 
 ---
 
-Add Status Detection
-
-Status | Symbol | What It Means
--- | -- | --
-Running | ● green | Agent is actively working
-Waiting | ◐ yellow | Needs your input
-Idle | ○ gray | Ready for commands
-Error | ✕ red | Something went wrong
-
-
+Sometimes a agent session is complete but the changes require review or input from other parties
+In this case, I want to be able to note these as waiting for input/complete
+This should change the icon from needs input to some other state
+This should be reset when interacted with
+Perhaps there is a way to link with the related PR to pull in any changes/updates from team members or notify when there is ready for more action 

--- a/internal/app/app_prefix_palette_visibility.go
+++ b/internal/app/app_prefix_palette_visibility.go
@@ -36,9 +36,14 @@ func (a *App) prefixActionVisible(action string) bool {
 		default:
 			return a.center.HasTabs()
 		}
-	case "close_tab", "detach_tab", "reattach_tab", "restart_tab", "toggle_complete_tab":
+	case "close_tab", "detach_tab", "reattach_tab", "restart_tab":
 		if a.focusedPane == messages.PaneSidebarTerminal {
 			return true
+		}
+		return a.center.HasTabs()
+	case "toggle_complete_tab":
+		if a.focusedPane == messages.PaneDashboard {
+			return a.activeWorkspace != nil
 		}
 		return a.center.HasTabs()
 	default:

--- a/internal/app/app_prefix_palette_visibility.go
+++ b/internal/app/app_prefix_palette_visibility.go
@@ -36,7 +36,7 @@ func (a *App) prefixActionVisible(action string) bool {
 		default:
 			return a.center.HasTabs()
 		}
-	case "close_tab", "detach_tab", "reattach_tab", "restart_tab":
+	case "close_tab", "detach_tab", "reattach_tab", "restart_tab", "toggle_complete_tab":
 		if a.focusedPane == messages.PaneSidebarTerminal {
 			return true
 		}

--- a/internal/app/app_ui_prefix.go
+++ b/internal/app/app_ui_prefix.go
@@ -42,6 +42,7 @@ var prefixCommandTable = []prefixCommand{
 	{Sequence: []string{"t", "d"}, Desc: "detach tab", Action: "detach_tab"},
 	{Sequence: []string{"t", "r"}, Desc: "reattach tab", Action: "reattach_tab"},
 	{Sequence: []string{"t", "s"}, Desc: "restart tab", Action: "restart_tab"},
+	{Sequence: []string{"t", "c"}, Desc: "toggle complete", Action: "toggle_complete_tab"},
 }
 
 // Prefix mode helpers (leader key)
@@ -284,6 +285,14 @@ func (a *App) runPrefixAction(action string) tea.Cmd {
 			return a.center.RestartActiveTab()
 		case messages.PaneSidebarTerminal:
 			return a.sidebarTerminal.RestartActiveTab()
+		}
+		return nil
+	case "toggle_complete_tab":
+		if a.focusedPane != messages.PaneCenter {
+			return nil
+		}
+		if a.center.ToggleActiveTabComplete() {
+			return a.persistActiveWorkspaceTabs()
 		}
 		return nil
 	default:

--- a/internal/app/app_ui_prefix.go
+++ b/internal/app/app_ui_prefix.go
@@ -288,11 +288,19 @@ func (a *App) runPrefixAction(action string) tea.Cmd {
 		}
 		return nil
 	case "toggle_complete_tab":
-		if a.focusedPane != messages.PaneCenter {
-			return nil
-		}
-		if a.center.ToggleActiveTabComplete() {
-			return a.persistActiveWorkspaceTabs()
+		switch a.focusedPane {
+		case messages.PaneCenter:
+			if a.center.ToggleActiveTabComplete() {
+				return a.persistActiveWorkspaceTabs()
+			}
+		case messages.PaneDashboard:
+			if a.activeWorkspace == nil {
+				return nil
+			}
+			wsID := string(a.activeWorkspace.ID())
+			if a.center.ToggleWorkspaceComplete(wsID) {
+				return a.persistWorkspaceTabs(wsID)
+			}
 		}
 		return nil
 	default:

--- a/internal/ui/center/model_input.go
+++ b/internal/ui/center/model_input.go
@@ -280,6 +280,13 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 					tab.mu.Unlock()
 				}
 
+				// Clear complete mark on user interaction
+				tab.mu.Lock()
+				if tab.MarkedComplete {
+					tab.MarkedComplete = false
+				}
+				tab.mu.Unlock()
+
 				// Forward ALL keys to terminal (no Ctrl interceptions)
 				input := common.KeyToBytes(msg)
 				if len(input) > 0 {

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -151,10 +151,11 @@ func (m *Model) isChatTab(tab *Tab) bool {
 type ConversationStatus int
 
 const (
-	ConvStatusIdle    ConversationStatus = iota // ○ gray   - no session or session ended
-	ConvStatusRunning                           // ● green  - actively working
-	ConvStatusWaiting                           // ◐ yellow - session alive, needs attention
-	ConvStatusError                             // ✕ red    - something went wrong
+	ConvStatusIdle     ConversationStatus = iota // ○ gray   - no session or session ended
+	ConvStatusRunning                            // ● green  - actively working
+	ConvStatusWaiting                            // ◐ yellow - session alive, needs attention
+	ConvStatusError                              // ✕ red    - something went wrong
+	ConvStatusComplete                           // ✓ info   - marked complete, awaiting review
 )
 
 // TabConversationStatus returns the display status for a chat tab based on
@@ -170,11 +171,16 @@ func (m *Model) TabConversationStatus(tab *Tab) ConversationStatus {
 	tab.mu.Lock()
 	detached := tab.Detached
 	running := tab.Running
+	markedComplete := tab.MarkedComplete
 	sessionName := tab.SessionName
 	if sessionName == "" && tab.Agent != nil {
 		sessionName = tab.Agent.Session
 	}
 	tab.mu.Unlock()
+
+	if markedComplete {
+		return ConvStatusComplete
+	}
 
 	// Throttled diagnostic: log once per 5 seconds per tab to help debug unexpected ○ indicators.
 	now := time.Now()
@@ -217,6 +223,7 @@ func (m *Model) GetWorkspaceStatuses() map[string]common.AgentStatus {
 			tab.mu.Lock()
 			running := tab.Running
 			detached := tab.Detached
+			markedComplete := tab.MarkedComplete
 			sessionName := tab.SessionName
 			if sessionName == "" && tab.Agent != nil {
 				sessionName = tab.Agent.Session
@@ -224,19 +231,23 @@ func (m *Model) GetWorkspaceStatuses() map[string]common.AgentStatus {
 			tab.mu.Unlock()
 
 			var s common.AgentStatus
-			switch {
-			case !running && !detached:
-				s = common.AgentStatusIdle
-			case running && !detached:
-				s = common.AgentStatusWaiting // upgraded to Running by caller if tmux active
-			default:
-				// detached=true: PTY dropped or user detached.
-				// If a tmux session name is known the session may still be alive
-				// and waiting for input — show Waiting so the user notices it.
-				if sessionName != "" {
-					s = common.AgentStatusWaiting
-				} else {
+			if markedComplete {
+				s = common.AgentStatusComplete
+			} else {
+				switch {
+				case !running && !detached:
 					s = common.AgentStatusIdle
+				case running && !detached:
+					s = common.AgentStatusWaiting // upgraded to Running by caller if tmux active
+				default:
+					// detached=true: PTY dropped or user detached.
+					// If a tmux session name is known the session may still be alive
+					// and waiting for input — show Waiting so the user notices it.
+					if sessionName != "" {
+						s = common.AgentStatusWaiting
+					} else {
+						s = common.AgentStatusIdle
+					}
 				}
 			}
 			if s > best {

--- a/internal/ui/center/model_render_tabbar.go
+++ b/internal/ui/center/model_render_tabbar.go
@@ -58,6 +58,8 @@ func (m *Model) renderTabBar() string {
 				indicator = common.Icons.Waiting + " "
 			case ConvStatusError:
 				indicator = common.Icons.Error + " "
+			case ConvStatusComplete:
+				indicator = common.Icons.Complete + " "
 			default: // ConvStatusIdle
 				indicator = common.Icons.Idle + " "
 			}
@@ -76,6 +78,8 @@ func (m *Model) renderTabBar() string {
 				return common.ColorWarning()
 			case ConvStatusError:
 				return common.ColorError()
+			case ConvStatusComplete:
+				return common.ColorInfo()
 			default:
 				return common.ColorMuted()
 			}
@@ -99,6 +103,8 @@ func (m *Model) renderTabBar() string {
 				nameStyle = nameStyle.Foreground(common.ColorWarning())
 			case ConvStatusError:
 				nameStyle = nameStyle.Foreground(common.ColorError())
+			case ConvStatusComplete:
+				nameStyle = nameStyle.Foreground(common.ColorInfo())
 			default:
 				nameStyle = nameStyle.Foreground(common.ColorMuted())
 			}
@@ -120,6 +126,8 @@ func (m *Model) renderTabBar() string {
 				nameStyled = lipgloss.NewStyle().Foreground(common.ColorWarning()).Render(name)
 			case ConvStatusError:
 				nameStyled = lipgloss.NewStyle().Foreground(common.ColorError()).Render(name)
+			case ConvStatusComplete:
+				nameStyled = lipgloss.NewStyle().Foreground(common.ColorInfo()).Render(name)
 			default:
 				nameStyled = m.styles.Muted.Render(name)
 			}

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -46,6 +46,7 @@ type Tab struct {
 	closed            uint32
 	closing           uint32
 	Running           bool   // Whether the agent is actively running
+	MarkedComplete    bool   // Whether the user has marked this tab as complete
 	readerActive      bool   // Guard to ensure only one PTY read loop per tab
 	readerActiveState uint32 // Mirrors readerActive for lock-free atomic reads
 	// Buffer PTY output to avoid rendering partial screen updates.

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -218,13 +218,16 @@ func (m *Model) GetTabsInfo() ([]data.TabInfo, int) {
 		tab.mu.Lock()
 		running := tab.Running
 		detached := tab.Detached
+		markedComplete := tab.MarkedComplete
 		sessionName := tab.SessionName
 		if sessionName == "" && tab.Agent != nil {
 			sessionName = tab.Agent.Session
 		}
 		tab.mu.Unlock()
 		status := "stopped"
-		if detached {
+		if markedComplete {
+			status = "complete"
+		} else if detached {
 			status = "detached"
 		} else if running {
 			status = "running"
@@ -251,13 +254,16 @@ func (m *Model) GetTabsInfoForWorkspace(wsID string) ([]data.TabInfo, int) {
 		tab.mu.Lock()
 		running := tab.Running
 		detached := tab.Detached
+		markedComplete := tab.MarkedComplete
 		sessionName := tab.SessionName
 		if sessionName == "" && tab.Agent != nil {
 			sessionName = tab.Agent.Session
 		}
 		tab.mu.Unlock()
 		status := "stopped"
-		if detached {
+		if markedComplete {
+			status = "complete"
+		} else if detached {
 			status = "detached"
 		} else if running {
 			status = "running"
@@ -278,6 +284,25 @@ func (m *Model) GetTabsInfoForWorkspace(wsID string) ([]data.TabInfo, int) {
 func (m *Model) HasWorkspaceState(wsID string) bool {
 	_, ok := m.tabsByWorkspace[wsID]
 	return ok
+}
+
+// ToggleActiveTabComplete toggles the "complete" mark on the active tab.
+// When marked complete, the tab shows a distinct status icon.
+// The mark is automatically cleared when the user sends input to the tab.
+func (m *Model) ToggleActiveTabComplete() bool {
+	tabs := m.getTabs()
+	activeIdx := m.getActiveTabIdx()
+	if len(tabs) == 0 || activeIdx >= len(tabs) {
+		return false
+	}
+	tab := tabs[activeIdx]
+	if tab == nil || tab.isClosed() || !m.isChatTab(tab) {
+		return false
+	}
+	tab.mu.Lock()
+	tab.MarkedComplete = !tab.MarkedComplete
+	tab.mu.Unlock()
+	return true
 }
 
 // HasDiffViewer returns true if the active tab has a diff viewer.

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -305,6 +305,43 @@ func (m *Model) ToggleActiveTabComplete() bool {
 	return true
 }
 
+// ToggleWorkspaceComplete toggles the "complete" mark on all chat tabs in a workspace.
+// Returns true if any tabs were toggled.
+func (m *Model) ToggleWorkspaceComplete(wsID string) bool {
+	tabs := m.tabsByWorkspace[wsID]
+	if len(tabs) == 0 {
+		return false
+	}
+	// Determine the target state: if any tab is not complete, mark all complete.
+	// If all are already complete, unmark all.
+	allComplete := true
+	chatCount := 0
+	for _, tab := range tabs {
+		if tab == nil || tab.isClosed() || !m.isChatTab(tab) {
+			continue
+		}
+		chatCount++
+		tab.mu.Lock()
+		if !tab.MarkedComplete {
+			allComplete = false
+		}
+		tab.mu.Unlock()
+	}
+	if chatCount == 0 {
+		return false
+	}
+	newState := !allComplete
+	for _, tab := range tabs {
+		if tab == nil || tab.isClosed() || !m.isChatTab(tab) {
+			continue
+		}
+		tab.mu.Lock()
+		tab.MarkedComplete = newState
+		tab.mu.Unlock()
+	}
+	return true
+}
+
 // HasDiffViewer returns true if the active tab has a diff viewer.
 func (m *Model) HasDiffViewer() bool {
 	tabs := m.getTabs()

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -37,16 +37,17 @@ func (m *Model) addDetachedTab(ws *data.Workspace, info data.TabInfo) {
 		ca = time.Now().Unix()
 	}
 	tab := &Tab{
-		ID:            generateTabID(),
-		Name:          displayName,
-		Assistant:     info.Assistant,
-		Workspace:     ws,
-		SessionName:   info.SessionName,
-		Detached:      true,
-		Running:       false,
-		Terminal:      term,
-		createdAt:     ca,
-		lastFocusedAt: time.Unix(ca, 0),
+		ID:             generateTabID(),
+		Name:           displayName,
+		Assistant:      info.Assistant,
+		Workspace:      ws,
+		SessionName:    info.SessionName,
+		Detached:       true,
+		Running:        false,
+		MarkedComplete: info.Status == "complete",
+		Terminal:       term,
+		createdAt:      ca,
+		lastFocusedAt:  time.Unix(ca, 0),
 	}
 	isChat := m.isChatTab(tab)
 	term.IgnoreCursorVisibilityControls = isChat
@@ -94,6 +95,7 @@ func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID,
 		SessionName: sessionName,
 		Detached:    true,
 		Running:     false,
+		MarkedComplete: info.Status == "complete",
 		// Placeholder tabs are immediately queued for async reattach.
 		reattachInFlight: true,
 		Terminal:         term,

--- a/internal/ui/common/icons.go
+++ b/internal/ui/common/icons.go
@@ -4,13 +4,14 @@ package common
 // Uses Unicode characters with fallbacks for broad terminal support
 var Icons = struct {
 	// Status indicators
-	Clean   string
-	Dirty   string
-	Running string
-	Waiting string
-	Idle    string
-	Pending string
-	Error   string
+	Clean    string
+	Dirty    string
+	Running  string
+	Waiting  string
+	Idle     string
+	Pending  string
+	Error    string
+	Complete string
 
 	// Actions
 	Add    string
@@ -44,13 +45,14 @@ var Icons = struct {
 	Spinner []string
 }{
 	// Status indicators
-	Clean:   "✓",
-	Dirty:   "●",
-	Running: "●",
-	Waiting: "◐",
-	Idle:    "○",
-	Pending: "◌",
-	Error:   "✕",
+	Clean:    "✓",
+	Dirty:    "●",
+	Running:  "●",
+	Waiting:  "◐",
+	Idle:     "○",
+	Pending:  "◌",
+	Error:    "✕",
+	Complete: "✓",
 
 	// Actions
 	Add:    "+",

--- a/internal/ui/common/status.go
+++ b/internal/ui/common/status.go
@@ -7,10 +7,11 @@ import "image/color"
 type AgentStatus int
 
 const (
-	AgentStatusIdle    AgentStatus = iota // ○ gray  - no agent or disconnected
-	AgentStatusRunning                    // ● green  - actively working
-	AgentStatusWaiting                    // ◐ yellow - needs user input
-	AgentStatusError                      // ✕ red    - something went wrong
+	AgentStatusIdle     AgentStatus = iota // ○ gray  - no agent or disconnected
+	AgentStatusRunning                     // ● green  - actively working
+	AgentStatusWaiting                     // ◐ yellow - needs user input
+	AgentStatusError                       // ✕ red    - something went wrong
+	AgentStatusComplete                    // ✓ info   - marked complete, awaiting review
 )
 
 // AgentStatusIcon returns the display icon for the given status.
@@ -22,6 +23,8 @@ func AgentStatusIcon(s AgentStatus) string {
 		return Icons.Waiting
 	case AgentStatusError:
 		return Icons.Error
+	case AgentStatusComplete:
+		return Icons.Complete
 	default:
 		return Icons.Idle
 	}
@@ -36,6 +39,8 @@ func AgentStatusColor(s AgentStatus) color.Color {
 		return ColorWarning()
 	case AgentStatusError:
 		return ColorError()
+	case AgentStatusComplete:
+		return ColorInfo()
 	default:
 		return ColorMuted()
 	}


### PR DESCRIPTION
This pull request adds the ability to mark chat tabs as "complete" without deleting them, visually distinguishing completed sessions and supporting workflows where further review or input is required. It introduces a new "complete" status, updates UI elements to reflect this state, and provides keyboard shortcuts to toggle the status for individual tabs or entire workspaces. The "complete" mark is automatically cleared when the user interacts with the tab.

**Feature: Mark chat as complete**

- Added a `MarkedComplete` field to the `Tab` struct and logic to toggle this field for the active tab or all chat tabs in a workspace. The mark is cleared on user input. (`internal/ui/center/model_tab.go`, `internal/ui/center/model_tabs_actions.go`, `internal/ui/center/model_input.go`) [[1]](diffhunk://#diff-949cf8f5d7819e398a598f29f9ed4c974aa321cb37caa68b75fc513befadfb7cR49) [[2]](diffhunk://#diff-b950a854fd72bd23a8a013817a5b15e297aa1c8acc2bcfa5499db33aceb7caacR289-R344) [[3]](diffhunk://#diff-7720cd52e99ba212259a0c83ae62047b0a0947023d202703aeae0db736f27991R283-R289)
- Updated tab status calculations and workspace status aggregation to include the new "complete" state. (`internal/ui/center/model_pty_status.go`, `internal/ui/common/status.go`) [[1]](diffhunk://#diff-2dab5992e14e25a41f83558a6269a89fba386a17a2d332fdf226830224fcdd44R158) [[2]](diffhunk://#diff-2dab5992e14e25a41f83558a6269a89fba386a17a2d332fdf226830224fcdd44R174-R184) [[3]](diffhunk://#diff-2dab5992e14e25a41f83558a6269a89fba386a17a2d332fdf226830224fcdd44R226-R236) [[4]](diffhunk://#diff-2dab5992e14e25a41f83558a6269a89fba386a17a2d332fdf226830224fcdd44R252) [[5]](diffhunk://#diff-f785b279d1c3b2b5453c2d0bbd10183397c5522d8ba6ad0ebdd3d0850e5a3a6dR14) [[6]](diffhunk://#diff-f785b279d1c3b2b5453c2d0bbd10183397c5522d8ba6ad0ebdd3d0850e5a3a6dR26-R27) [[7]](diffhunk://#diff-f785b279d1c3b2b5453c2d0bbd10183397c5522d8ba6ad0ebdd3d0850e5a3a6dR42-R43)
- Persisted and restored the "complete" status for tabs when saving and reloading workspace state. (`internal/ui/center/model_tabs_actions.go`, `internal/ui/center/model_tabs_restore.go`) [[1]](diffhunk://#diff-b950a854fd72bd23a8a013817a5b15e297aa1c8acc2bcfa5499db33aceb7caacR221-R230) [[2]](diffhunk://#diff-b950a854fd72bd23a8a013817a5b15e297aa1c8acc2bcfa5499db33aceb7caacR257-R266) [[3]](diffhunk://#diff-74779c2b3e7b472421da0d11bc7d3135a5909d5f72cdbc0ed75949bd9c52c6ceR47) [[4]](diffhunk://#diff-74779c2b3e7b472421da0d11bc7d3135a5909d5f72cdbc0ed75949bd9c52c6ceR98)

**UI/UX: Visual indicators and controls**

- Added a new icon and color for the "complete" status in the tab bar and status displays. (`internal/ui/center/model_render_tabbar.go`, `internal/ui/common/icons.go`) [[1]](diffhunk://#diff-649b37c4258859a4c1d250f05afb7e8705b75c2107ab15161c16d9f377bf4df3R61-R62) [[2]](diffhunk://#diff-649b37c4258859a4c1d250f05afb7e8705b75c2107ab15161c16d9f377bf4df3R81-R82) [[3]](diffhunk://#diff-649b37c4258859a4c1d250f05afb7e8705b75c2107ab15161c16d9f377bf4df3R106-R107) [[4]](diffhunk://#diff-649b37c4258859a4c1d250f05afb7e8705b75c2107ab15161c16d9f377bf4df3R129-R130) [[5]](diffhunk://#diff-78bd935885b479f655d45d8268c17254afe6ad1d0148fe5bcbb48b2a679f5fefR14) [[6]](diffhunk://#diff-78bd935885b479f655d45d8268c17254afe6ad1d0148fe5bcbb48b2a679f5fefR55)
- Added a prefix command (`t c`) to toggle the "complete" status for the active tab or all tabs in a workspace, with appropriate visibility and action handling. (`internal/app/app_ui_prefix.go`, `internal/app/app_prefix_palette_visibility.go`) [[1]](diffhunk://#diff-f6c42466083d8e9f416ee519b67f44acf5880458e0923a76b5249c4612512849R45) [[2]](diffhunk://#diff-f6c42466083d8e9f416ee519b67f44acf5880458e0923a76b5249c4612512849R290-R305) [[3]](diffhunk://#diff-5ff4f8bfdc3c35001cc77b0475febf31eb3a25e246dcfb69fbd39128e615883aR44-R48)

**Documentation**

- Updated the issue template to describe the new "mark as complete" feature and its intended workflow. (`ISSUE.md`)