### PR TITLE
feat: added system theme as an option

### DIFF
--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -18,7 +18,7 @@ type UISettings struct {
 func defaultUISettings() UISettings {
 	return UISettings{
 		ShowKeymapHints:  false,
-		Theme:            "gruvbox",
+		Theme:            "system",
 		TmuxServer:       "",
 		TmuxConfigPath:   "",
 		TmuxSyncInterval: "",

--- a/internal/ui/common/theme.go
+++ b/internal/ui/common/theme.go
@@ -8,6 +8,9 @@ import (
 type ThemeID string
 
 const (
+	// System theme (reads from omarchy)
+	ThemeSystem ThemeID = "system"
+
 	// Dark themes
 	ThemeTokyoNight ThemeID = "tokyo-night"
 	ThemeDracula    ThemeID = "dracula"
@@ -70,7 +73,9 @@ type Theme struct {
 
 // AvailableThemes returns all predefined themes, grouped by family.
 func AvailableThemes() []Theme {
-	return []Theme{
+	themes := []Theme{
+		// System theme (omarchy pass-through)
+		SystemTheme(),
 		// Gruvbox family (default)
 		GruvboxTheme(),
 		GruvboxLightTheme(),
@@ -100,6 +105,7 @@ func AvailableThemes() []Theme {
 		EverforestTheme(),
 		AyuDarkTheme(),
 	}
+	return themes
 }
 
 // GetTheme returns a theme by ID, defaulting to Gruvbox.

--- a/internal/ui/common/theme_system.go
+++ b/internal/ui/common/theme_system.go
@@ -1,0 +1,146 @@
+package common
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+// omarchyThemeDir returns the path to the omarchy current theme directory.
+func omarchyThemeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "omarchy", "current", "theme")
+}
+
+// omarchyThemeName reads the current omarchy theme name.
+func omarchyThemeName() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".config", "omarchy", "current", "theme.name"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// parseColorsToml parses a simple key = "value" TOML file into a map.
+func parseColorsToml(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	colors := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		val = strings.Trim(val, "\"")
+		colors[key] = val
+	}
+	return colors, scanner.Err()
+}
+
+// blendColor blends two hex colors by the given ratio (0.0 = a, 1.0 = b).
+func blendColor(a, b string, ratio float64) string {
+	ca, err1 := colorful.Hex(a)
+	cb, err2 := colorful.Hex(b)
+	if err1 != nil || err2 != nil {
+		return a
+	}
+	return ca.BlendLab(cb, ratio).Hex()
+}
+
+// SystemTheme builds a theme from the current omarchy system colors.
+// Falls back to Gruvbox if omarchy config is not available.
+func SystemTheme() Theme {
+	dir := omarchyThemeDir()
+	if dir == "" {
+		return fallbackSystemTheme()
+	}
+
+	colors, err := parseColorsToml(filepath.Join(dir, "colors.toml"))
+	if err != nil {
+		return fallbackSystemTheme()
+	}
+
+	get := func(key, fallback string) string {
+		if v, ok := colors[key]; ok && v != "" {
+			return v
+		}
+		return fallback
+	}
+
+	bg := get("background", "#282828")
+	fg := get("foreground", "#ebdbb2")
+	accent := get("accent", "#d79921")
+	color0 := get("color0", bg)
+	color1 := get("color1", "#cc241d")
+	color2 := get("color2", "#98971a")
+	color3 := get("color3", "#d79921")
+	color4 := get("color4", "#458588")
+	color6 := get("color6", "#689d6a")
+	color8 := get("color8", "#928374")
+	selBg := get("selection_background", blendColor(bg, fg, 0.2))
+	activTab := get("active_tab_background", accent)
+
+	name := omarchyThemeName()
+	if name == "" {
+		name = "System"
+	} else {
+		name = "System (" + name + ")"
+	}
+
+	return Theme{
+		ID:   ThemeSystem,
+		Name: name,
+		Colors: ThemeColors{
+			Background:    lipgloss.Color(bg),
+			Foreground:    lipgloss.Color(fg),
+			Muted:         lipgloss.Color(color8),
+			Border:        lipgloss.Color(blendColor(bg, fg, 0.15)),
+			BorderFocused: lipgloss.Color(accent),
+
+			Primary:   lipgloss.Color(accent),
+			Secondary: lipgloss.Color(color6),
+			Success:   lipgloss.Color(color2),
+			Warning:   lipgloss.Color(color3),
+			Error:     lipgloss.Color(color1),
+			Info:      lipgloss.Color(color4),
+
+			Surface0: lipgloss.Color(color0),
+			Surface1: lipgloss.Color(blendColor(bg, fg, 0.05)),
+			Surface2: lipgloss.Color(blendColor(bg, fg, 0.10)),
+			Surface3: lipgloss.Color(blendColor(bg, fg, 0.15)),
+
+			Selection: lipgloss.Color(selBg),
+			Highlight: lipgloss.Color(activTab),
+		},
+	}
+}
+
+// fallbackSystemTheme returns a Gruvbox theme labeled as System when omarchy is unavailable.
+func fallbackSystemTheme() Theme {
+	t := GruvboxTheme()
+	t.ID = ThemeSystem
+	t.Name = "System"
+	return t
+}

--- a/internal/ui/common/theme_system.go
+++ b/internal/ui/common/theme_system.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,16 +33,14 @@ func omarchyThemeName() string {
 
 // parseColorsToml parses a simple key = "value" TOML file into a map.
 func parseColorsToml(path string) (map[string]string, error) {
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
 	colors := make(map[string]string)
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
@@ -56,7 +53,7 @@ func parseColorsToml(path string) (map[string]string, error) {
 		val = strings.Trim(val, "\"")
 		colors[key] = val
 	}
-	return colors, scanner.Err()
+	return colors, nil
 }
 
 // blendColor blends two hex colors by the given ratio (0.0 = a, 1.0 = b).


### PR DESCRIPTION
This pull request adds support for a new "system" theme that dynamically reads and applies color settings from the user's Omarchy configuration. The "system" theme is now the default, and the implementation gracefully falls back to Gruvbox if the Omarchy config is unavailable. The main changes are grouped below.

**System Theme Integration:**

* Introduced a new `ThemeSystem` constant and added it as the first option in the available themes list, making it the default theme. (`internal/ui/common/theme.go`, [[1]](diffhunk://#diff-a52eb3a562609b21e4b92dd89c471aa0d307d90f4ce62525ba40101e53238439R11-R13) [[2]](diffhunk://#diff-a52eb3a562609b21e4b92dd89c471aa0d307d90f4ce62525ba40101e53238439L73-R78) [[3]](diffhunk://#diff-a52eb3a562609b21e4b92dd89c471aa0d307d90f4ce62525ba40101e53238439R108)
* Changed the default theme in user settings from `"gruvbox"` to `"system"`. (`internal/config/user_settings.go`, [internal/config/user_settings.goL21-R21](diffhunk://#diff-7ca17e37dd87a3beb9ddda53225afc41fc7fc5f81b8f0e36eee7d9e045235199L21-R21))
* Added a new file, `theme_system.go`, which implements the logic to read Omarchy theme colors from the filesystem, parse them, and construct a `Theme` dynamically. If Omarchy is not available, it falls back to a Gruvbox-based "System" theme. (`internal/ui/common/theme_system.go`, [internal/ui/common/theme_system.goR1-R146](diffhunk://#diff-07f62bee34a1245f348757d2ac49116cb60a57c85b30bea8a003ff0a17e12054R1-R146))
