### PR TITLE
updated to force refesh when restarting to get latest status

### DIFF
--- a/internal/app/app_input_keys.go
+++ b/internal/app/app_input_keys.go
@@ -1,11 +1,14 @@
 package app
 
 import (
+	"strings"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/tlepoid/tumuxi/internal/logging"
 	"github.com/tlepoid/tumuxi/internal/messages"
+	"github.com/tlepoid/tumuxi/internal/ui/common"
 )
 
 // syncActiveWorkspacesToDashboard syncs the active workspace state from center to dashboard.
@@ -15,17 +18,71 @@ func (a *App) syncActiveWorkspacesToDashboard() {
 		return
 	}
 	activeWorkspaces := make(map[string]bool)
-	if !a.tmuxActivitySettled {
-		a.dashboard.SetActiveWorkspaces(activeWorkspaces)
-		return
-	}
-	for wsID := range a.tmuxActiveWorkspaceIDs {
-		activeWorkspaces[wsID] = true
+	if a.tmuxActivitySettled {
+		for wsID := range a.tmuxActiveWorkspaceIDs {
+			activeWorkspaces[wsID] = true
+		}
 	}
 	a.dashboard.SetActiveWorkspaces(activeWorkspaces)
+	// Start with statuses derived from persisted workspace metadata so that
+	// indicators are visible immediately on load (before any workspace is visited).
+	statuses := a.workspaceStatusesFromMetadata()
+	// Overlay live statuses from the center model for workspaces that have
+	// been visited and have in-memory tabs.
 	if a.center != nil {
-		a.dashboard.SetWorkspaceStatuses(a.center.GetWorkspaceStatuses())
+		for wsID, s := range a.center.GetWorkspaceStatuses() {
+			statuses[wsID] = s
+		}
 	}
+	a.dashboard.SetWorkspaceStatuses(statuses)
+}
+
+// workspaceStatusesFromMetadata derives agent statuses from persisted workspace
+// OpenTabs metadata. This provides immediate status indicators on startup before
+// any workspace tabs have been restored in the center model.
+func (a *App) workspaceStatusesFromMetadata() map[string]common.AgentStatus {
+	result := make(map[string]common.AgentStatus)
+	for i := range a.projects {
+		for j := range a.projects[i].Workspaces {
+			ws := &a.projects[i].Workspaces[j]
+			if len(ws.OpenTabs) == 0 {
+				continue
+			}
+			best := common.AgentStatusIdle
+			for _, tab := range ws.OpenTabs {
+				if tab.Assistant == "" {
+					continue
+				}
+				if a.config != nil && a.config.Assistants != nil {
+					if _, ok := a.config.Assistants[tab.Assistant]; !ok {
+						continue
+					}
+				}
+				var s common.AgentStatus
+				status := strings.ToLower(strings.TrimSpace(tab.Status))
+				switch status {
+				case "complete":
+					s = common.AgentStatusComplete
+				case "running":
+					s = common.AgentStatusWaiting
+				case "detached":
+					if tab.SessionName != "" {
+						s = common.AgentStatusWaiting
+					} else {
+						s = common.AgentStatusIdle
+					}
+				default:
+					s = common.AgentStatusIdle
+				}
+				if s > best {
+					best = s
+				}
+			}
+			wsID := string(ws.ID())
+			result[wsID] = best
+		}
+	}
+	return result
 }
 
 // handleKeyPress handles keyboard input

--- a/internal/ui/common/status.go
+++ b/internal/ui/common/status.go
@@ -1,6 +1,10 @@
 package common
 
-import "image/color"
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
 
 // AgentStatus is the aggregated conversation status for a workspace,
 // derived from its tabs and used for dashboard display.
@@ -30,18 +34,28 @@ func AgentStatusIcon(s AgentStatus) string {
 	}
 }
 
+// Agent status colors remain constant across themes for consistent recognition.
+var (
+	colorStatusRunning  = lipgloss.Color("#98C379") // green
+	colorStatusWaiting  = lipgloss.Color("#E5C07B") // yellow
+	colorStatusError    = lipgloss.Color("#E06C75") // red
+	colorStatusComplete = lipgloss.Color("#61AFEF") // blue
+	colorStatusIdle     = lipgloss.Color("#5C6370") // gray
+)
+
 // AgentStatusColor returns the display color for the given status.
+// Colors are fixed across themes so status indicators are always recognizable.
 func AgentStatusColor(s AgentStatus) color.Color {
 	switch s {
 	case AgentStatusRunning:
-		return ColorSuccess()
+		return colorStatusRunning
 	case AgentStatusWaiting:
-		return ColorWarning()
+		return colorStatusWaiting
 	case AgentStatusError:
-		return ColorError()
+		return colorStatusError
 	case AgentStatusComplete:
-		return ColorInfo()
+		return colorStatusComplete
 	default:
-		return ColorMuted()
+		return colorStatusIdle
 	}
 }


### PR DESCRIPTION
This pull request updates how workspace status indicators are initialized and displayed in the dashboard. Now, status indicators are immediately visible on startup by deriving them from persisted workspace metadata, even before any workspace is visited or tabs are restored. Live statuses from the in-memory model are then overlaid as available.

**Improvements to workspace status initialization and display:**

* Modified `syncActiveWorkspacesToDashboard` to set workspace statuses using both persisted metadata and live data, ensuring immediate and accurate status indicators on dashboard load.
* Added the `workspaceStatusesFromMetadata` helper to derive agent statuses from persisted `OpenTabs` metadata, providing immediate status indicators for workspaces before any in-memory state is available.

**Dependency and import updates:**

* Added imports for `strings` and `github.com/tlepoid/tumuxi/internal/ui/common` to support status parsing and type usage.
