### PR TITLE
added sort by status to commands

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,11 +1,8 @@
-# Issue #15: Add ability to mark a chat as complete without deleting
+# Issue #17: Add the ability to sort the sessions by status
 
-https://github.com/tlepoid/tumuxi/issues/15
+https://github.com/tlepoid/tumuxi/issues/17
 
 ---
 
-Sometimes a agent session is complete but the changes require review or input from other parties
-In this case, I want to be able to note these as waiting for input/complete
-This should change the icon from needs input to some other state
-This should be reset when interacted with
-Perhaps there is a way to link with the related PR to pull in any changes/updates from team members or notify when there is ready for more action 
+Currently, sessions are sorted by project. 
+This is nice to understand what sessions align with which project but with many projects it can take a bit of time to switch, maybe we can elevate the active sessions to the top

--- a/internal/app/app_ui_prefix.go
+++ b/internal/app/app_ui_prefix.go
@@ -43,6 +43,7 @@ var prefixCommandTable = []prefixCommand{
 	{Sequence: []string{"t", "r"}, Desc: "reattach tab", Action: "reattach_tab"},
 	{Sequence: []string{"t", "s"}, Desc: "restart tab", Action: "restart_tab"},
 	{Sequence: []string{"t", "c"}, Desc: "toggle complete", Action: "toggle_complete_tab"},
+	{Sequence: []string{"s"}, Desc: "sort by status", Action: "toggle_sort_by_status"},
 }
 
 // Prefix mode helpers (leader key)
@@ -148,7 +149,18 @@ func (a *App) prefixInputToken(msg tea.KeyPressMsg) (string, bool) {
 }
 
 func (a *App) prefixCommands() []prefixCommand {
-	return prefixCommandTable
+	cmds := make([]prefixCommand, len(prefixCommandTable))
+	copy(cmds, prefixCommandTable)
+	for i := range cmds {
+		if cmds[i].Action == "toggle_sort_by_status" && a.dashboard != nil {
+			if a.dashboard.IsSortByStatus() {
+				cmds[i].Desc = "sort by date"
+			} else {
+				cmds[i].Desc = "sort by status"
+			}
+		}
+	}
+	return cmds
 }
 
 // matchingPrefixCommands intentionally does not apply prefixActionVisible.
@@ -285,6 +297,15 @@ func (a *App) runPrefixAction(action string) tea.Cmd {
 			return a.center.RestartActiveTab()
 		case messages.PaneSidebarTerminal:
 			return a.sidebarTerminal.RestartActiveTab()
+		}
+		return nil
+	case "toggle_sort_by_status":
+		sortByStatus := a.dashboard.ToggleSortByStatus()
+		if a.toast != nil {
+			if sortByStatus {
+				return a.toast.Show("Sort: by status", common.ToastInfo, 2*time.Second)
+			}
+			return a.toast.Show("Sort: by date", common.ToastInfo, 2*time.Second)
 		}
 		return nil
 	case "toggle_complete_tab":

--- a/internal/ui/dashboard/dashboard_state.go
+++ b/internal/ui/dashboard/dashboard_state.go
@@ -66,8 +66,18 @@ func (m *Model) rebuildRows() {
 		{Type: RowSpacer},
 	}
 
+	// Build project pointer list; optionally sort by agent status.
+	sortedProjects := make([]*data.Project, len(m.projects))
 	for i := range m.projects {
-		project := &m.projects[i]
+		sortedProjects[i] = &m.projects[i]
+	}
+	if m.sortByStatus {
+		sort.SliceStable(sortedProjects, func(i, j int) bool {
+			return m.bestProjectStatus(sortedProjects[i]) < m.bestProjectStatus(sortedProjects[j])
+		})
+	}
+
+	for _, project := range sortedProjects {
 		mainWS := m.getMainWorkspace(project)
 		mainWSID := ""
 		if mainWS != nil {
@@ -136,6 +146,41 @@ func (m *Model) clampScrollOffset() {
 	}
 }
 
+// statusSortPriority returns a sort rank for agent status.
+// Lower values sort first (more urgent statuses at the top).
+func statusSortPriority(s common.AgentStatus) int {
+	switch s {
+	case common.AgentStatusRunning:
+		return 0
+	case common.AgentStatusWaiting:
+		return 1
+	case common.AgentStatusError:
+		return 2
+	case common.AgentStatusIdle:
+		return 3
+	case common.AgentStatusComplete:
+		return 4
+	default:
+		return 5
+	}
+}
+
+// bestProjectStatus returns the highest-priority agent status across all
+// workspaces in a project.
+func (m *Model) bestProjectStatus(p *data.Project) int {
+	best := statusSortPriority(common.AgentStatusIdle) // default if no workspaces
+	for i := range p.Workspaces {
+		ws := &p.Workspaces[i]
+		wsID := string(ws.ID())
+		if s, ok := m.workspaceStatuses[wsID]; ok {
+			if pri := statusSortPriority(s); pri < best {
+				best = pri
+			}
+		}
+	}
+	return best
+}
+
 func (m *Model) sortedWorkspaces(project *data.Project) []*data.Workspace {
 	existingRoots := make(map[string]bool, len(project.Workspaces))
 	workspaces := make([]*data.Workspace, 0, len(project.Workspaces)+len(m.creatingWorkspaces))
@@ -157,6 +202,15 @@ func (m *Model) sortedWorkspaces(project *data.Project) []*data.Workspace {
 	}
 
 	sort.SliceStable(workspaces, func(i, j int) bool {
+		// When sort-by-status is enabled, primary sort by agent status
+		if m.sortByStatus {
+			si := statusSortPriority(m.workspaceStatuses[string(workspaces[i].ID())])
+			sj := statusSortPriority(m.workspaceStatuses[string(workspaces[j].ID())])
+			if si != sj {
+				return si < sj
+			}
+		}
+		// Fallback: creation date (newest first), then name, then root
 		if workspaces[i].Created.Equal(workspaces[j].Created) {
 			if workspaces[i].Name == workspaces[j].Name {
 				return workspaces[i].Root < workspaces[j].Root
@@ -211,4 +265,17 @@ func (m *Model) Projects() []data.Project {
 // ClearActiveRoot resets the active workspace selection to "Home".
 func (m *Model) ClearActiveRoot() {
 	m.activeRoot = ""
+}
+
+// IsSortByStatus returns whether status-based sorting is active.
+func (m *Model) IsSortByStatus() bool {
+	return m.sortByStatus
+}
+
+// ToggleSortByStatus toggles between sorting by status and sorting by date.
+// Returns the new state (true = sorting by status).
+func (m *Model) ToggleSortByStatus() bool {
+	m.sortByStatus = !m.sortByStatus
+	m.rebuildRows()
+	return m.sortByStatus
 }

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -85,6 +85,9 @@ type Model struct {
 	activeWorkspaceIDs map[string]bool               // Workspace IDs with active agents (synced from center)
 	workspaceStatuses  map[string]common.AgentStatus // Per-workspace agent status (synced from center)
 
+	// Sort mode
+	sortByStatus bool // When true, sort projects and workspaces by agent status
+
 	// Styles
 	styles common.Styles
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to sort sessions (projects and workspaces) by their agent status, in addition to the existing sort by date. The implementation includes UI updates, new sorting logic, and a keyboard shortcut for toggling the sort mode.

**Sorting feature and UI enhancements:**

* Added a new prefix command (`s`) to toggle sorting by status, with dynamic description updates in the command palette based on the current sort mode (`internal/app/app_ui_prefix.go`). [[1]](diffhunk://#diff-f6c42466083d8e9f416ee519b67f44acf5880458e0923a76b5249c4612512849R46) [[2]](diffhunk://#diff-f6c42466083d8e9f416ee519b67f44acf5880458e0923a76b5249c4612512849L151-R163)
* Implemented toast notifications to inform users when the sort mode changes (`internal/app/app_ui_prefix.go`).

**Sorting logic and data model changes:**

* Updated the dashboard state to support sorting projects and workspaces by agent status, including new helper methods (`IsSortByStatus`, `ToggleSortByStatus`, `bestProjectStatus`, and `statusSortPriority`) and a new `sortByStatus` field in the model (`internal/ui/dashboard/dashboard_state.go`, `internal/ui/dashboard/model.go`). [[1]](diffhunk://#diff-9e258bf31a6196866158f8f8b152902b41ce33742a4a6ff1fd7587dff36f0227R69-R80) [[2]](diffhunk://#diff-9e258bf31a6196866158f8f8b152902b41ce33742a4a6ff1fd7587dff36f0227R149-R183) [[3]](diffhunk://#diff-9e258bf31a6196866158f8f8b152902b41ce33742a4a6ff1fd7587dff36f0227R205-R213) [[4]](diffhunk://#diff-9e258bf31a6196866158f8f8b152902b41ce33742a4a6ff1fd7587dff36f0227R269-R281) [[5]](diffhunk://#diff-8ad60b21509d63af54dad077821e5ca6e6642f450a9d64f777377d0aba587430R88-R90)

**Documentation:**

* Updated the issue template to reflect the new feature request for sorting sessions by status (`ISSUE.md`).